### PR TITLE
Changes to support integration testing.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,8 +20,8 @@ test \
 
 # Build and use local toolchain.
 build:i386 \
-  --build_tag_filters i386 \
-  --test_tag_filters i386 \
+  --build_tag_filters i386,i386-only \
+  --test_tag_filters i386,i386-only \
   --crosstool_top=//tools/toolchain \
   --cpu=i386 \
   --compiler=g++ \

--- a/kernel/BUILD.bazel
+++ b/kernel/BUILD.bazel
@@ -14,15 +14,3 @@ kernel_binary(
         "//util:check",
     ],
 )
-
-kernel_test(
-    name = "kernel_test",
-    srcs = [
-        "kernel_test.cc",
-    ],
-    deps = [
-        "//kernel/arch:init",
-        "//libc:stdio",
-        "//util:check",
-    ],
-)

--- a/kernel/arch/BUILD.bazel
+++ b/kernel/arch/BUILD.bazel
@@ -1,6 +1,12 @@
 load("//kernel/arch:arch.bzl", "arch_file", "arch_library")
+load("//kernel:templates.bzl", "kernel_test")
 
 package(default_visibility = ["//visibility:public"])
+
+arch_library(
+    name = "boot",
+    hdrs = [],
+)
 
 arch_library(
     name = "init",
@@ -8,6 +14,19 @@ arch_library(
         "//kernel/arch/common:memory",
         "//kernel/arch/common:serial",
         "//kernel/arch/common:tty",
+    ],
+)
+
+kernel_test(
+    name = "init_ktest",
+    srcs = [
+        "init_ktest.cc",
+    ],
+    deps = [
+        ":init",
+        "//kernel/testing:macros",
+        "//libc:stdio",
+        "//util:check",
     ],
 )
 

--- a/kernel/arch/arch.bzl
+++ b/kernel/arch/arch.bzl
@@ -5,8 +5,7 @@ def arch_library(name, **kwargs):
     })
 
     tags = kwargs.pop("tags", [])
-    tags.append("arch-only")
-    tags = depset(tags).to_list()  # de-dupe
+    tags.extend(["arch-only", "i386"])
 
     native.cc_library(
         name = name,
@@ -18,8 +17,7 @@ def arch_library(name, **kwargs):
 
 def arch_file(name, **kwargs):
     tags = kwargs.pop("tags", [])
-    tags.append("arch-only")
-    tags = depset(tags).to_list()  # de-dupe
+    tags.extend(["arch-only", "i386"])
 
     native.filegroup(
         name = name,

--- a/kernel/arch/i386/BUILD.bazel
+++ b/kernel/arch/i386/BUILD.bazel
@@ -44,9 +44,13 @@ cc_library(
     hdrs = [
         "//kernel/arch:init.h",
     ],
-    tags = ["i386-only"],
+    tags = [
+        "i386",
+        "i386-only",
+    ],
     visibility = ["//kernel/arch:__pkg__"],
     deps = [
+        "//cxx:kernel",
         "//kernel/arch/common:tty",
         "//kernel/arch/i386/boot",
         "//kernel/arch/i386/boot:multiboot",
@@ -58,10 +62,23 @@ cc_library(
         "//kernel/arch/i386/io:serial",
         "//kernel/arch/i386/memory:linear",
         "//libc:assert",
+        "//libc:kernel",
         "//libc:stdio",
         "//libc:string",
         "//util:check",
         "//util:optional",
         "//util:status",
+    ],
+)
+
+cc_library(
+    name = "boot",
+    tags = [
+        "i386",
+        "i386-only",
+    ],
+    visibility = ["//kernel/arch:__pkg__"],
+    deps = [
+        "//kernel/arch/i386/boot",
     ],
 )

--- a/kernel/arch/i386/boot/BUILD.bazel
+++ b/kernel/arch/i386/boot/BUILD.bazel
@@ -9,9 +9,16 @@ cc_library(
     hdrs = [
         "boot.h",
     ],
-    tags = ["i386-only"],
+    tags = [
+        "i386",
+        "i386-only",
+    ],
     deps = [
         ":multiboot",
+        "//cxx:kernel",
+        "//kernel/arch/i386/io:io_port",
+        "//kernel/arch/i386/io:serial",
+        "//libc:kernel",
     ],
 )
 

--- a/kernel/arch/i386/boot/boot.cc
+++ b/kernel/arch/i386/boot/boot.cc
@@ -52,6 +52,8 @@ void InitializeStubs() {
 extern "C" void PreKernelMain(multiboot_info* multiboot_ptr) {
   InitializeStubs();
   multiboot_information = *multiboot_ptr;
+  // Write newline to get output on a different line than preamble text.
+  KernelPut('\n');
   KernelPuts("== Initialized Pre-Kernel Main ==");
 }
 

--- a/kernel/arch/i386/boot/boot.cc
+++ b/kernel/arch/i386/boot/boot.cc
@@ -1,4 +1,8 @@
+#include "cxx/kernel.h"
 #include "kernel/arch/i386/boot/multiboot.h"
+#include "kernel/arch/i386/io/io_port.h"
+#include "kernel/arch/i386/io/serial.h"
+#include "libc/kernel.h"
 
 namespace arch {
 
@@ -6,8 +10,49 @@ multiboot_info multiboot_information;
 
 namespace {
 
+util::Status KernelPut(char c) {
+  const uint16_t base = 0x3F8;
+  SerialPort com1 = SerialPort::Create(/*port=*/IoPort(base),
+                                       /*interrupt=*/IoPort(base + 1),
+                                       /*fifo*/ IoPort(base + 2),
+                                       /*line_control=*/IoPort(base + 3),
+                                       /*modem_control=*/IoPort(base + 4),
+                                       /*line_status=*/IoPort(base + 5));
+  com1.Write(c);
+  return {};
+}
+
+void KernelPuts(const char* message) {
+  for (const char* ptr = message; *ptr != '\0'; ptr++) {
+    KernelPut(*ptr);
+  }
+  KernelPut('\n');
+}
+
+void InitializeStubs() {
+  libc::kernel_put = KernelPut;
+  libc::kernel_panic = [](const char* message) {
+    KernelPuts("Pre-Kernel Panic!");
+    KernelPuts("Message: ");
+    KernelPuts(message);
+    IoPort new_qemu_shutdown_port(0x604);
+    new_qemu_shutdown_port.outw(0x2000);
+    KernelPuts(
+        "QEMU did not shut down. This is expected for older versions of QEMU. "
+        "Trying older variant of shutting down QEMU.");
+    IoPort old_qemu_shutdown_port(0xB004);
+    old_qemu_shutdown_port.outw(0x2000);
+    KernelPuts("Could not shut down. Looping forever.");
+    while (true) {
+    }
+  };
+  cxx::kernel_panic = libc::kernel_panic;
+}
+
 extern "C" void PreKernelMain(multiboot_info* multiboot_ptr) {
+  InitializeStubs();
   multiboot_information = *multiboot_ptr;
+  KernelPuts("== Initialized Pre-Kernel Main ==");
 }
 
 }  // namespace

--- a/kernel/arch/i386/init.cc
+++ b/kernel/arch/i386/init.cc
@@ -20,13 +20,14 @@ namespace arch {
 
 namespace {
 
-INTERRUPT_SERVICE_ROUTINE(DummyHandler,
-                          { libc::puts("== Dummy Handler 0x80 =="); });
+INTERRUPT_SERVICE_ROUTINE(DummyHandler) {
+  libc::puts("== Dummy Handler 0x80 ==");
+}
 
-INTERRUPT_SERVICE_ROUTINE(DoubleFault, {
+INTERRUPT_SERVICE_ROUTINE(DoubleFault) {
   libc::puts("== Double Fault ==");
   libc::abort();
-});
+}
 
 InterruptDescriptorTable<256> idt;
 
@@ -86,8 +87,6 @@ void InitializeCOM1() {
                             /*line_control=*/IoPort(base + 3),
                             /*modem_control=*/IoPort(base + 4),
                             /*line_status=*/IoPort(base + 5));
-  // Write newline to get output on a different line than preamble text.
-  com1.Value().Write('\n');
 }
 
 LinearAllocator<100> linear_allocator;

--- a/kernel/arch/i386/interrupt/macros.h
+++ b/kernel/arch/i386/interrupt/macros.h
@@ -3,11 +3,8 @@
 
 #define _INTERRUPT_SERVICE_ROUTINE_STRINGIZE(x) #x
 
-#define INTERRUPT_SERVICE_ROUTINE(name, function) \
-  extern "C" void name();                         \
-  namespace {                                     \
-  extern "C" void name##Internal() function       \
-  }                                               \
+#define INTERRUPT_SERVICE_ROUTINE(name)               \
+  extern "C" void name();                             \
   asm(".global " #name                              \
       "\n"                                          \
       ".align 4\n" #name                            \
@@ -17,6 +14,7 @@
       "call " _INTERRUPT_SERVICE_ROUTINE_STRINGIZE(name##Internal)   \
       "\n"                                          \
       "popal\n"                                     \
-      "iret\n")
+      "iret\n"); \
+  extern "C" void name##Internal()
 
 #endif  // KERNEL_ARCH_I386_INTERRUPT_MACROS_H

--- a/kernel/arch/i386/io/BUILD.bazel
+++ b/kernel/arch/i386/io/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     ],
     deps = [
         ":io_port",
+        "//cxx",
         "//kernel/arch/common:serial",
     ],
 )

--- a/kernel/arch/init_ktest.cc
+++ b/kernel/arch/init_ktest.cc
@@ -1,13 +1,11 @@
+
 #include "kernel/arch/init.h"
+#include "kernel/testing/macros.h"
 #include "libc/stdio.h"
-#include "libc/stdlib.h"
 #include "util/check.h"
 
-extern "C" void KernelMain() {
+KERNEL_TEST(Initialize) {
   CHECK_OR_RETURN(const auto& boot, arch::Initialize());
-  libc::puts("== Kernel Test ==");
   libc::printf("Boot Info: {tty=0x%p, com1=0x%p, allocator=0x%p}\n", boot.tty,
                boot.com1, boot.allocator);
-  libc::puts("<<KERNEL TEST COMPLETE>>");
-  libc::abort();
 }

--- a/kernel/templates.bzl
+++ b/kernel/templates.bzl
@@ -62,21 +62,17 @@ def kernel_binary(name, **kwargs):
     )
 
     deps = kwargs.pop("deps", [])
-    deps.append("//cxx")
-    deps = depset(deps).to_list()  # de-dupe
+    deps.extend(["//cxx", "//kernel/arch:boot"])
 
     # Add arch-specific linker file as input and use it.
     additional_linker_inputs = kwargs.pop("additional_linker_inputs", [])
     additional_linker_inputs.append("//kernel/arch:linker.ld")
-    additional_linker_inputs = depset(additional_linker_inputs).to_list()  # de-dupe
     linkopts = kwargs.pop("linkopts", [])
     linkopts.append("-T $(location //kernel/arch:linker.ld)")
-    linkopts = depset(linkopts).to_list()  # de-dupe
 
     # # Add architecture tags to ensure it's properly captured in ... expansion.
     tags = kwargs.pop("tags", [])
     tags.extend(["arch-only", "i386"])
-    tags = depset(tags).to_list()  # de-dupe
 
     # crtbegin, crti, crtend, and crtn are specifically ordered such that the
     # global constructors and destructors are called correctly. crti/crtbegin
@@ -93,17 +89,16 @@ def kernel_binary(name, **kwargs):
         **kwargs
     )
 
-def kernel_test(name, srcs, deps, timeout="short", **kwargs):
+def kernel_test(name, timeout = "short", **kwargs):
     tags = kwargs.pop("tags", [])
     tags.extend(["arch-only", "i386"])
-    tags = depset(tags).to_list()  # de-dupe
 
     kernel = "%s_kernel_binary" % name
     kernel_binary(
         name = kernel,
-        srcs = srcs,
-        deps = deps,
+        srcs = kwargs.pop("srcs", []),
+        deps = kwargs.pop("deps", []),
         tags = tags,
         **kwargs
     )
-    qemu_test(name = name, kernel = kernel, tags = tags, timeout=timeout, **kwargs)
+    qemu_test(name = name, kernel = kernel, tags = tags, timeout = timeout, **kwargs)

--- a/kernel/testing/BUILD.bazel
+++ b/kernel/testing/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//kernel:templates.bzl", "kernel_test")
+
+cc_library(
+    name = "macros",
+    hdrs = [
+        "macros.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libc:stdio",
+        "//libc:stdlib",
+    ],
+)
+
+kernel_test(
+    name = "macros_ktest",
+    srcs = [
+        "macros_ktest.cc",
+    ],
+    deps = [
+        ":macros",
+    ],
+)

--- a/kernel/testing/macros.h
+++ b/kernel/testing/macros.h
@@ -1,0 +1,21 @@
+#ifndef KERNEL_TESTING_MACROS_H
+#define KERNEL_TESTING_MACROS_H
+
+#include "libc/stdio.h"
+#include "libc/stdlib.h"
+
+// KERNEL_TEST defined a kernel test function for use in integration testing.
+#define KERNEL_TEST(name)                         \
+  static void KernelMain##name();                 \
+  namespace {                                     \
+  extern "C" void KernelMain() {                  \
+    libc::puts("<< TEST " #name " STARTED >>");   \
+    KernelMain##name();                           \
+    libc::puts("<< TEST " #name " COMPLETED >>"); \
+    libc::puts("<<KERNEL TEST COMPLETE>>");       \
+    libc::abort();                                \
+  }                                               \
+  }                                               \
+  static void KernelMain##name()
+
+#endif  //  KERNEL_TESTING_MACROS_H

--- a/kernel/testing/macros_ktest.cc
+++ b/kernel/testing/macros_ktest.cc
@@ -1,0 +1,4 @@
+
+#include "kernel/testing/macros.h"
+
+KERNEL_TEST(Empty) {}


### PR DESCRIPTION
Includes:

 * A test macro for defining the kernel test main.
 * Bootstrapping the libc print functions with outputting to the serial port during kernel main along with kernel panic bootstrapping.
 * Remove "de-duping" calls since those actually don't do anything.
 * Two integration tests:
   * Verifies the test macro works with no contents.
   * Verifies that arch::Initialize() works.